### PR TITLE
Bottom tab bar on vehicle card (jump to Input without scrolling)

### DIFF
--- a/daddy_hackulator_MASTER_v5.html
+++ b/daddy_hackulator_MASTER_v5.html
@@ -878,6 +878,17 @@
         overflow-x: auto;
       }
 
+      /* Bottom mirror of the tab bar — sits below Results/Deals so you can
+         jump back to Input without scrolling to the top of the card. */
+      .vehicle-tabs-bottom {
+        border-bottom: none;
+        border-top: 2px solid var(--border);
+        position: sticky;
+        bottom: 0;
+        background: var(--card-bg, #fff);
+        z-index: 5;
+      }
+
       .vehicle-tabs .tab-btn {
         background: transparent;
         color: #666666;
@@ -18097,6 +18108,13 @@ body.dark-theme {
       <div class="deal-detail-output" style="display:none;"></div>
     </div>
   </div>
+  <!-- Bottom tab bar — mirror of the top tabs so you can jump back to
+       Input from the bottom of Results/Deals without scrolling up. -->
+  <div class="vehicle-tabs vehicle-tabs-bottom">
+    <button class="vehicle-tab-btn active" data-tab="input">🔢 Input</button>
+    <button class="vehicle-tab-btn" data-tab="results">✅ Results</button>
+    <button class="vehicle-tab-btn" data-tab="deals">📋 Deals</button>
+  </div>
 </div>`;
       }
 
@@ -18301,20 +18319,25 @@ body.dark-theme {
           });
         });
 
-        // Tab switching
+        // Tab switching — top and bottom bars stay in sync (both bars share
+        // the .vehicle-tab-btn class, so activate ALL buttons for the chosen
+        // tab, not just the clicked one).
         card.querySelectorAll(".vehicle-tab-btn").forEach(function (tabBtn) {
           tabBtn.addEventListener("click", function () {
+            var tab = tabBtn.dataset.tab;
             card.querySelectorAll(".vehicle-tab-btn").forEach(function (b) {
-              b.classList.remove("active");
+              b.classList.toggle("active", b.dataset.tab === tab);
             });
             card.querySelectorAll(".vehicle-tab-content").forEach(function (c) {
-              c.classList.remove("active");
+              c.classList.toggle("active", c.dataset.tab === tab);
             });
-            tabBtn.classList.add("active");
-            var target = card.querySelector(
-              '.vehicle-tab-content[data-tab="' + tabBtn.dataset.tab + '"]',
-            );
-            if (target) target.classList.add("active");
+            // Clicking a BOTTOM-bar tab scrolls the card back into view so you
+            // land at the top of the newly shown tab (the whole point of the
+            // bottom bar — jump back to Input without manual scrolling).
+            if (tabBtn.closest(".vehicle-tabs-bottom")) {
+              var top = card.getBoundingClientRect().top + window.pageYOffset - 10;
+              window.scrollTo({ top: top, behavior: "smooth" });
+            }
           });
         });
 
@@ -20828,19 +20851,13 @@ body.dark-theme {
         entry.results = result;
         renderResults(card, result, dealType);
 
-        // Switch to results tab
+        // Switch to results tab (sync BOTH the top and bottom tab bars)
         card.querySelectorAll(".vehicle-tab-btn").forEach(function (b) {
-          b.classList.remove("active");
+          b.classList.toggle("active", b.dataset.tab === "results");
         });
         card.querySelectorAll(".vehicle-tab-content").forEach(function (c) {
-          c.classList.remove("active");
+          c.classList.toggle("active", c.dataset.tab === "results");
         });
-        var resTab = card.querySelector('.vehicle-tab-btn[data-tab="results"]');
-        if (resTab) resTab.classList.add("active");
-        var resContent = card.querySelector(
-          '.vehicle-tab-content[data-tab="results"]',
-        );
-        if (resContent) resContent.classList.add("active");
         // Pairwise auto-render disabled — its data was redundant with the
         // Vehicle Comparison matrix (per-vehicle pairwise W-L tally now lives
         // in the canonical matrix as a single row). Function is kept for

--- a/daddy_hackulator_ULTIMATE_v5.html
+++ b/daddy_hackulator_ULTIMATE_v5.html
@@ -878,6 +878,17 @@
         overflow-x: auto;
       }
 
+      /* Bottom mirror of the tab bar — sits below Results/Deals so you can
+         jump back to Input without scrolling to the top of the card. */
+      .vehicle-tabs-bottom {
+        border-bottom: none;
+        border-top: 2px solid var(--border);
+        position: sticky;
+        bottom: 0;
+        background: var(--card-bg, #fff);
+        z-index: 5;
+      }
+
       .vehicle-tabs .tab-btn {
         background: transparent;
         color: #666666;
@@ -17694,6 +17705,13 @@ body.dark-theme {
       <div class="deal-detail-output" style="display:none;"></div>
     </div>
   </div>
+  <!-- Bottom tab bar — mirror of the top tabs so you can jump back to
+       Input from the bottom of Results/Deals without scrolling up. -->
+  <div class="vehicle-tabs vehicle-tabs-bottom">
+    <button class="vehicle-tab-btn active" data-tab="input">🔢 Input</button>
+    <button class="vehicle-tab-btn" data-tab="results">✅ Results</button>
+    <button class="vehicle-tab-btn" data-tab="deals">📋 Deals</button>
+  </div>
 </div>`;
       }
 
@@ -17895,20 +17913,25 @@ body.dark-theme {
           });
         });
 
-        // Tab switching
+        // Tab switching — top and bottom bars stay in sync (both bars share
+        // the .vehicle-tab-btn class, so activate ALL buttons for the chosen
+        // tab, not just the clicked one).
         card.querySelectorAll(".vehicle-tab-btn").forEach(function (tabBtn) {
           tabBtn.addEventListener("click", function () {
+            var tab = tabBtn.dataset.tab;
             card.querySelectorAll(".vehicle-tab-btn").forEach(function (b) {
-              b.classList.remove("active");
+              b.classList.toggle("active", b.dataset.tab === tab);
             });
             card.querySelectorAll(".vehicle-tab-content").forEach(function (c) {
-              c.classList.remove("active");
+              c.classList.toggle("active", c.dataset.tab === tab);
             });
-            tabBtn.classList.add("active");
-            var target = card.querySelector(
-              '.vehicle-tab-content[data-tab="' + tabBtn.dataset.tab + '"]',
-            );
-            if (target) target.classList.add("active");
+            // Clicking a BOTTOM-bar tab scrolls the card back into view so you
+            // land at the top of the newly shown tab (the whole point of the
+            // bottom bar — jump back to Input without manual scrolling).
+            if (tabBtn.closest(".vehicle-tabs-bottom")) {
+              var top = card.getBoundingClientRect().top + window.pageYOffset - 10;
+              window.scrollTo({ top: top, behavior: "smooth" });
+            }
           });
         });
 
@@ -20302,19 +20325,13 @@ body.dark-theme {
         entry.results = result;
         renderResults(card, result, dealType);
 
-        // Switch to results tab
+        // Switch to results tab (sync BOTH the top and bottom tab bars)
         card.querySelectorAll(".vehicle-tab-btn").forEach(function (b) {
-          b.classList.remove("active");
+          b.classList.toggle("active", b.dataset.tab === "results");
         });
         card.querySelectorAll(".vehicle-tab-content").forEach(function (c) {
-          c.classList.remove("active");
+          c.classList.toggle("active", c.dataset.tab === "results");
         });
-        var resTab = card.querySelector('.vehicle-tab-btn[data-tab="results"]');
-        if (resTab) resTab.classList.add("active");
-        var resContent = card.querySelector(
-          '.vehicle-tab-content[data-tab="results"]',
-        );
-        if (resContent) resContent.classList.add("active");
         // Pairwise auto-render disabled — its data was redundant with the
         // Vehicle Comparison matrix (per-vehicle pairwise W-L tally now lives
         // in the canonical matrix as a single row). Function is kept for


### PR DESCRIPTION
## Summary
- Adds a **second Input / Results / Deals tab bar at the bottom of each vehicle card**, so you can switch back to Input from the end of a long Results/Deals view without scrolling up to the top bar.
- The bottom bar is **sticky** to the card's lower edge and mirrors the top bar.
- The tab-switch handler now activates **all** buttons for the chosen tab, so the top and bottom bars stay in sync (same for the post-calculate auto-switch to Results).
- Clicking a **bottom-bar** tab smooth-scrolls the card back into view, so you land at the top of the selected tab (the whole point — jump back to Input without manual scrolling).
- Applied to `daddy_hackulator_MASTER_v5.html` and `daddy_hackulator_ULTIMATE_v5.html`; both scripts syntax-verified with `node --check`.

## Test plan
- [ ] Calculate a vehicle → lands on Results; confirm both top and bottom bars show Results active
- [ ] Scroll to the bottom of Results, click **Input** on the bottom bar → the Input tab shows and the view scrolls to the top of the card
- [ ] Switch tabs from the top bar → confirm the bottom bar highlights the same tab (and vice-versa)
- [ ] Verify identical behavior in ULTIMATE_v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6jZimdexuN531cm3i9VU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf6jZimdexuN531cm3i9VU)_